### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python3
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="fbmessenger",
       version="0.1.0",


### PR DESCRIPTION
setuptools lets you do `python setup.py develop` which links your
dist-packages and scripts directly to your working copy, so you
can test changes without constantly reinstalling
